### PR TITLE
Update settings.py

### DIFF
--- a/full_auth/settings.py
+++ b/full_auth/settings.py
@@ -200,6 +200,9 @@ DJOSER = {
     'USER_CREATE_PASSWORD_RETYPE': True,
     'PASSWORD_RESET_CONFIRM_RETYPE': True,
     'TOKEN_MODEL': None,
+    'EMAIL': {
+        'activation': 'djoser.email.ActivationEmail',
+    },
     'SOCIAL_AUTH_ALLOWED_REDIRECT_URIS': getenv('REDIRECT_URLS').split(',')
 }
 


### PR DESCRIPTION
By default, djoser will not serve an email template for activation until specified causing account activation to fail. By mentioning `EMAIL` in the djoser configuration we are selecting djoser's default template for account activation.